### PR TITLE
Dependabot workspace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,25 +3,25 @@ updates:
 - package-ecosystem: cargo
   directory: "/cli"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 0
   commit-message:
     prefix: "[cli]"
 - package-ecosystem: cargo
   directory: "/lib"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 0
   commit-message:
     prefix: "[lib]"
 - package-ecosystem: cargo
   directory: "/gui"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 0
   commit-message:
     prefix: "[gui]"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,26 @@
 version: 2
 updates:
 - package-ecosystem: cargo
-  directory: "/"
+  directory: "/cli"
   schedule:
     interval: daily
-  # Disable the pull request limit for dependabot
   open-pull-requests-limit: 0
+  commit-message:
+    prefix: "[cli]"
+- package-ecosystem: cargo
+  directory: "/lib"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 0
+  commit-message:
+    prefix: "[lib]"
+- package-ecosystem: cargo
+  directory: "/gui"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 0
+  commit-message:
+    prefix: "[gui]"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
Dependabot seems to have a problem with cargo workspace. Thus, this PR splits the dependabot configuration for the lib, cli and gui crate.

Also, dependabot is only executed weekly from now on.