### PR TITLE
Replace nix based CI with normal cargo-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,29 +9,37 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  checks:
+  check:
+    name: Check
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3.1.0
-      - uses: cachix/install-nix-action@v18
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@v12
-        with:
-          name: distrox
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - run: nix --extra-experimental-features "nix-command flakes" flake check
 
-  dco-check:
-    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.1.0
+      - name: Checkout sources
+        uses: actions/checkout@v3.1.0
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
         with:
-          fetch-depth: 0
-      - name: Setup Python
-        uses: actions/setup-python@v4.3.0
+          toolchain: 1.65.0
+          override: true
+
+      - uses: swatinem/rust-cache@v2
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
         with:
-          python-version: '3.x'
-      - name: Install gitlint
-        run: pip install gitlint
-      - run: gitlint --commits $(git merge-base origin/master HEAD)..
+          command: check
+
+  # We need some "accummulation" job here because bors fails (timeouts) to
+  # listen on matrix builds.
+  # Hence, we have some kind of dummy here that bors can listen on
+  ci-success:
+    name: CI
+    if: ${{ success() }}
+    runs-on: ubuntu-latest
+    needs:
+      - check
+    steps:
+      - name: CI succeeded
+        run: exit 0
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.65.0
+          - stable
 
     steps:
       - name: Checkout sources
@@ -20,7 +25,7 @@ jobs:
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.65.0
+          toolchain: ${{ matrix.rust }}
           override: true
 
       - uses: swatinem/rust-cache@v2

--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,4 @@
 status = [
-    "checks",
-    "dco-check"
+    "CI",
 ]
 update_base_for_deletes = true


### PR DESCRIPTION
Because tauri fights against nix as hard as it can, we resort to normal cargo-check for now.
