### PR TITLE
Apparently, trunk wants to remove this file/dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
 
+      - name: Create dist dir
+        run: mkdir gui/frontend/dist
+
       - name: Run cargo check
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
It seems that during dev, the `trunk` binary wants to remove this directory.
But in CI we need it.

This PR fixes this issue.