### PR TITLE
Remove API mocking

### DIFF
--- a/gui/frontend/public/glue.js
+++ b/gui/frontend/public/glue.js
@@ -1,30 +1,11 @@
-var fn_login = async function (name) {
-    console.log("invoke login(${name}");
-}
-
-var fn_create_account = async function (name) {
-    console.log("invoke create_account(${name}");
-}
-
-if (typeof(window.__TAURI__) !== 'undefined') {
-    const invoke = window.__TAURI__.invoke
-
-    fn_login = async function (name) {
-        return await invoke("login", {name: name});
-    }
-
-    fn_create_account = async function (name) {
-        return await invoke("create_account", {name: name});
-    }
-}
-
+const invoke = window.__TAURI_INVOKE__
 
 export async function invokeLogin(name) {
-    return await fn_login(name);
+    return await invoke("login", {name: name});
 }
 
 export async function invokeCreateAccount(name) {
-    return await fn_create_account(name);
+    return await invoke("create_account", {name: name});
 }
 
 


### PR DESCRIPTION
As the devtools in tauri now work on my machine, we don't need this anymore.
