### PR TITLE
Fix distrox-lib-tests derivation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -125,6 +125,8 @@
         cargoArtifacts = distroxLibArtifacts;
         inherit nativeBuildInputs;
         inherit buildInputs;
+
+        doNotLinkInheritedArtifacts = true;
       };
 
       distrox-gui = craneLib.buildPackage {

--- a/flake.nix
+++ b/flake.nix
@@ -123,6 +123,8 @@
       distrox-lib-tests = craneLib.cargoNextest {
         inherit src;
         cargoArtifacts = distroxLibArtifacts;
+        inherit nativeBuildInputs;
+        inherit buildInputs;
       };
 
       distrox-gui = craneLib.buildPackage {


### PR DESCRIPTION
The derivation had different inputs than its artifacts derivation and needs `doNotLinkInheritedArtifacts = true` (for reasons I do not yet understand).